### PR TITLE
print search annotation warning as MiniZinc comment

### DIFF
--- a/trunk/chuffed/flatzinc/flatzinc.c
+++ b/trunk/chuffed/flatzinc/flatzinc.c
@@ -222,7 +222,7 @@ namespace FlatZinc {
 			}
 		} 
 		if (!hadSearchAnnotation) {
-			printf("No search annotation given. Defaulting to VSIDS!\n");
+			printf("% No search annotation given. Defaulting to VSIDS!\n");
 			if (!so.vsids) {
 				so.vsids = true;
 				engine.branching->add(&sat);


### PR DESCRIPTION
This tiny change assures that fzn_chuffed prints valid MiniZinc as output and that the output can be successfully parsed as MiniZinc solution.
